### PR TITLE
Adjust Testdata for CreateAPIKey() to Match v22.6.6 of ICS

### DIFF
--- a/testdata/auth/auth_apikey_response.json
+++ b/testdata/auth/auth_apikey_response.json
@@ -1,3 +1,1 @@
-{
-    "apikey": "123456789AbCdEfGhIjKlMnOpQrStUvWxYz987654321"
-}
+"123456789AbCdEfGhIjKlMnOpQrStUvWxYz987654321"


### PR DESCRIPTION
Fix for testdata prior to enforcing go build.